### PR TITLE
Add meta runtime dependency for runtime and buildtime automatically

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ To get more info about Software Collections, see:
 Usage (print this by running spec2scl -h)::
 
 
-    usage: spec2scl [-h] [--meta-specfile] [-i] [-m] [-s] [-k SKIP_FUNCTIONS]
-                        [-v VARIABLES] [-n | -l SCL_CONTENTS_LIST]
-                        [ARGUMENT [ARGUMENT ...]]
+    usage: spec2scl [-h] [--meta-specfile] [-i] [-r] [-b] [-k SKIP_FUNCTIONS]
+                    [-v VARIABLES] [-n | -l SCL_CONTENTS_LIST]
+                    [ARGUMENT [ARGUMENT ...]]
 
     Convert RPM specfile to be SCL ready.
 
@@ -30,9 +30,12 @@ Usage (print this by running spec2scl -h)::
       -i                    Convert in place (replaces old specfiles with the new
                             generated ones). Mandatory when multiple specfiles are
                             to be converted.
-      -m, --meta-runtime-dep
-                            If used, runtime dependency on the scl runtime package
-                            will be added. The dependency is not added by default.
+      -r, --no-meta-runtime-dep
+                            Don't add the runtime dependency on the scl runtime
+                            package.
+      -b, --no-meta-buildtime-dep
+                            Don't add the buildtime dependency on the scl runtime
+                            package.
       -k SKIP_FUNCTIONS, --skip-functions SKIP_FUNCTIONS
                             Comma separated list of transformer functions to skip
       -v VARIABLES, --variables VARIABLES

--- a/spec2scl/bin.py
+++ b/spec2scl/bin.py
@@ -34,9 +34,14 @@ def main():
                         required=False,
                         action='store_true'
                         )
-    parser.add_argument('-m', '--meta-runtime-dep',
+    parser.add_argument('-r', '--no-meta-runtime-dep',
                         required=False,
-                        help='If used, runtime dependency on the scl runtime package will be added. The dependency is not added by default.',
+                        help='Don\'t add the runtime dependency on the scl runtime package.',
+                        action='store_true'
+                        )
+    parser.add_argument('-b', '--no-meta-buildtime-dep',
+                        required=False,
+                        help='Don\'t add the buildtime dependency on the scl runtime package.',
                         action='store_true'
                         )
     parser.add_argument('-k', '--skip-functions',
@@ -98,7 +103,8 @@ def main():
 
     for spec in specs:
         options = {'scl_deps': scl_deps,
-                   'meta_runtime_dep': args.meta_runtime_dep,
+                   'no_meta_runtime_dep': args.no_meta_runtime_dep,
+                   'no_meta_buildtime_dep': args.no_meta_buildtime_dep,
                    'skip_functions': args.skip_functions.split(','),
                    'variables': args.variables,
                    'meta_spec': args.meta_specfile}

--- a/spec2scl/transformer.py
+++ b/spec2scl/transformer.py
@@ -12,7 +12,8 @@ class Transformer(object):
     def __init__(self, options={}):
         self.options = options
         self.options.setdefault('skip_functions', [])
-        self.options.setdefault('meta_runtime_dep', False)
+        self.options.setdefault('no_meta_runtime_dep', False)
+        self.options.setdefault('no_meta_buildtime_dep', False)
         self.options.setdefault('scl_deps', True)
         self.transformer_methods = self.collect_transformer_methods()
 

--- a/tests/test_generic_transformer.py
+++ b/tests/test_generic_transformer.py
@@ -112,13 +112,16 @@ class TestGenericTransformer(TransformerTestCase):
     def test_handle_name_macro(self, spec, expected):
         assert self.t.handle_name_macro(spec, self.t.handle_name_macro.matches[0], spec) == expected
 
-    @pytest.mark.parametrize(('spec', 'meta_runtime_dep', 'expected'), [
-        ('Requires:', False, 'Requires:'),
-        ('Requires:', True, '%{?scl:Requires: %{scl}-runtime}\nRequires:'),
+    @pytest.mark.parametrize(('spec', 'no_meta_runtime_dep', 'no_meta_buildtime_dep', 'expected'), [
+        ('Requires:', True, True, 'Requires:'),
+        ('Requires:', False, True, '%{?scl:Requires: %{scl}-runtime}\nRequires:'),
+        ('Requires:', True, False, '%{?scl:BuildRequires: %{scl}-runtime}\nRequires:'),
+        ('Requires:', False, False, '%{?scl:Requires: %{scl}-runtime}\n%{?scl:BuildRequires: %{scl}-runtime}\nRequires:'),
     ])
-    def test_handle_meta_runtime_dep(self, spec, meta_runtime_dep, expected):
-        self.t.options['meta_runtime_dep'] = meta_runtime_dep
-        assert self.t.handle_meta_runtime_dep(spec, None, spec) == expected
+    def test_handle_meta_deps(self, spec, no_meta_runtime_dep, no_meta_buildtime_dep, expected):
+        self.t.options['no_meta_runtime_dep'] = no_meta_runtime_dep
+        self.t.options['no_meta_buildtime_dep'] = no_meta_buildtime_dep
+        assert self.t.handle_meta_deps(spec, None, spec) == expected
 
     @pytest.mark.parametrize(('spec', 'expected'), [
         ('configure\n', scl_enable + 'configure\n' + scl_disable),


### PR DESCRIPTION
- Add meta-runtime dep for runtime automatically and change the switch to disable it (`-r, --no-meta-runtime-dep`) #16
- Add meta-runtime dep for buildtime as a counterpart of the above (`-b, --no-meta-buildtime-dep`) #12 
