### PR TITLE
Expect whitespace at line start (Issue #15) and some code documentation

### DIFF
--- a/spec2scl/bin.py
+++ b/spec2scl/bin.py
@@ -18,6 +18,7 @@ def handle_scl_deps(no_deps_convert, args_list_file):
 
 
 def main():
+    """Main CLI entry point."""
     parser = argparse.ArgumentParser(description='Convert RPM specfile to be SCL ready.')
     parser.add_argument('specfiles',
                         help='Paths to the specfiles or name of the meta package, see --meta-specfile.',

--- a/spec2scl/convertor.py
+++ b/spec2scl/convertor.py
@@ -5,7 +5,19 @@ from spec2scl import transformer
 
 class Convertor(object):
 
+    """The Convertor object is responsible for producing SCL-style specfiles.
+
+    The Convertor object can either convert a conventional spec file into
+    a Software Collection spec, or create a spec file for a metapackage.
+    """
+
     def __init__(self, spec, options=None):
+        """Initializes original spec and options.
+
+        Args:
+            spec: (str|list) The original spec file.
+            options: (dict|None) Options provided for the CLI command.
+        """
         spec = self.list_to_str(spec)
         self.original_spec = spec
         self.options = options or {}
@@ -16,12 +28,17 @@ class Convertor(object):
         return arg
 
     def convert(self):
+        """Convert a conventional spec file into a SCL-style spec, or create
+        a spec file for a metapackage, according to the --meta-specfile option.
+        """
         if self.options['meta_spec']:
             return self.meta_convert()
         else:
             return transformer.Transformer(self.options).transform(self.original_spec)
 
     def meta_convert(self):
+        """Create a spec file for Software Collection metapackage."""
+        # self.original_spec contains only the scl name provided with --meta-specfile
         data = transformer.MetaTransformer(self.original_spec, self.options['variables'])
         jinja_env = jinja2.Environment(loader=jinja2.ChoiceLoader([
             jinja2.FileSystemLoader(['/']),

--- a/spec2scl/decorators.py
+++ b/spec2scl/decorators.py
@@ -4,6 +4,9 @@ from spec2scl import settings
 
 
 def matches(pattern, one_line=True, sections=settings.RUNTIME_SECTIONS, flags=0):
+    """Convert the provided arguments into attributes of the function object,
+    which are further processed by the base transformer class.
+    """
     if not one_line:
         flags = re.MULTILINE
 

--- a/spec2scl/transformer.py
+++ b/spec2scl/transformer.py
@@ -7,6 +7,13 @@ from spec2scl import specfile
 
 
 class Transformer(object):
+
+    """A base Transformer class.
+
+    Converts tags and macro definitions in a conventional
+    spec file into a Software Collection spec file.
+    """
+
     subtransformers = []
 
     def __init__(self, options={}):
@@ -23,6 +30,11 @@ class Transformer(object):
         return t
 
     def collect_transformer_methods(self):
+        """Return a list of methods decorated with matches.
+
+        Returns:
+            list of tuple of (<method>, <pattern>, <one line>, <sections>)
+        """
         transformers = []
 
         for v in vars(type(self)).values():
@@ -30,7 +42,6 @@ class Transformer(object):
                 for i in range(len(v.matches)):
                     transformers.append(
                         (getattr(self, v.__name__), v.matches[i], v.one_line[i], v.sections[i]))
-
         return transformers
 
     def transform_one_liners(self, original_spec, section_name, section_text):
@@ -60,6 +71,11 @@ class Transformer(object):
         return section_text
 
     def transform(self, original_spec, transformers=[]):
+        """Initialize spec2scl.transformers and perform conversion
+        by each subtransformer.
+        Returns:
+            converted spec file as a Specfile object
+        """
         spec = specfile.Specfile(original_spec)
         import spec2scl.transformers
         self.subtransformers = transformers or map(

--- a/spec2scl/transformers/__init__.py
+++ b/spec2scl/transformers/__init__.py
@@ -1,3 +1,14 @@
+"""Package initialization.
+
+Basically equivalent to:
+from spec2scl.transformers import generic
+from spec2scl.transformers import perl
+from spec2scl.transformers import php
+from spec2scl.transformers import python
+from spec2scl.transformers import R
+from spec2scl.transformers import ruby
+"""
+
 import importlib
 import os
 

--- a/spec2scl/transformers/generic.py
+++ b/spec2scl/transformers/generic.py
@@ -83,7 +83,7 @@ class GenericTransformer(transformer.Transformer):
                     return '{0}{1}{2}{3}'.format(text[:index], runtime_dep, buildtime_dep, text[index:])
         return text
 
-    @matches(r'^%?configure\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
-    @matches(r'^make\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
+    @matches(r'^\s*%?configure\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
+    @matches(r'^\s*make\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
     def handle_configure_make(self, original_spec, pattern, text):
         return self.sclize_all_commands(pattern, text)

--- a/spec2scl/transformers/perl.py
+++ b/spec2scl/transformers/perl.py
@@ -9,7 +9,7 @@ class PerlTransformer(transformer.Transformer):
         super(PerlTransformer, self).__init__(options)
 
     @matches(r'^[^\n]*%{__perl}\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
-    @matches(r'^perl\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)  # carefully here, "perl" will occur often in the specfile
+    @matches(r'^\s*perl\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)  # carefully here, "perl" will occur often in the specfile
     @matches(r'./Build', one_line=False)
     def handle_perl_specific_commands(self, original_spec, pattern, text):
         return self.sclize_all_commands(pattern, text)

--- a/spec2scl/transformers/ruby.py
+++ b/spec2scl/transformers/ruby.py
@@ -12,7 +12,7 @@ class RubyTransformer(transformer.Transformer):
              one_line=False,
              sections=settings.RUNTIME_SECTIONS)  # not to match string like "rubygem install"
     @matches(r'%gem_install\s*', one_line=False, sections=settings.RUNTIME_SECTIONS)
-    @matches(r'^ruby\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
+    @matches(r'^\s*ruby\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
     @matches(r'testrb\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
     @matches(r'testrb2\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)
     @matches(r'(?<![-.])rspec\s+', one_line=False, sections=settings.RUNTIME_SECTIONS)

--- a/tests/test_R_transformer.py
+++ b/tests/test_R_transformer.py
@@ -4,6 +4,7 @@ from spec2scl.transformers.R import RTransformer
 
 from tests.transformer_test_case import TransformerTestCase, scl_enable, scl_disable
 
+
 class TestRTransformer(TransformerTestCase):
     def setup_method(self, method):
         self.t = RTransformer({})
@@ -14,7 +15,7 @@ class TestRTransformer(TransformerTestCase):
     def test_R_specific_commands_not_matching(self, spec):
         spec = self.make_prep(spec)
         handler = self.t.handle_R_specific_commands
-        assert self.get_pattern_for_spec(handler, spec) == None
+        assert self.get_pattern_for_spec(handler, spec) is None
 
     @pytest.mark.parametrize(('spec', 'expected'), [
         ('R CMD foo bar', scl_enable + 'R CMD foo bar\n' + scl_disable),
@@ -22,5 +23,6 @@ class TestRTransformer(TransformerTestCase):
     ])
     def test_R_specific_commands_matching(self, spec, expected):
         spec = self.make_prep(spec)
-        handler = self.t.handle_R_specific_commands
-        assert self.t.handle_R_specific_commands(spec, self.get_pattern_for_spec(handler, spec), spec) == self.make_prep(expected)
+        pattern = self.get_pattern_for_spec(self.t.handle_R_specific_commands, spec)
+        assert pattern
+        assert self.t.handle_R_specific_commands(spec, pattern, spec) == self.make_prep(expected)

--- a/tests/test_generic_transformer.py
+++ b/tests/test_generic_transformer.py
@@ -133,8 +133,10 @@ class TestGenericTransformer(TransformerTestCase):
         ('%configure --foo \\n --bar', scl_enable + '%configure --foo \\n --bar\n' + scl_disable),
         ('make ', scl_enable + 'make \n' + scl_disable),
         ('make foo\n', scl_enable + 'make foo\n' + scl_disable),
+        ('  make foo\n', scl_enable + '  make foo\n' + scl_disable),
     ])
     def test_handle_configure_make(self, spec, expected):
         spec = self.make_prep(spec)
-        handler = self.t.handle_configure_make
-        assert self.t.handle_configure_make(spec, self.get_pattern_for_spec(handler, spec), spec) == self.make_prep(expected)
+        pattern = self.get_pattern_for_spec(self.t.handle_configure_make, spec)
+        assert pattern
+        assert self.t.handle_configure_make(spec, pattern, spec) == self.make_prep(expected)

--- a/tests/test_perl_transformer.py
+++ b/tests/test_perl_transformer.py
@@ -2,7 +2,7 @@ import pytest
 
 from spec2scl.transformers.perl import PerlTransformer
 
-from tests.transformer_test_case import TransformerTestCase
+from tests.transformer_test_case import TransformerTestCase, scl_enable, scl_disable
 
 
 class TestPerlTransformer(TransformerTestCase):
@@ -18,3 +18,16 @@ class TestPerlTransformer(TransformerTestCase):
             # general transformers also appear here, so just test all to
             # make sure we test the wanted one, too
             self.t.find_whole_commands(p, spec)
+
+    @pytest.mark.parametrize(('spec', 'expected'), [
+        ('perl Makefile.PL', scl_enable + 'perl Makefile.PL\n' + scl_disable),
+        (' perl Makefile.PL', scl_enable + ' perl Makefile.PL\n' + scl_disable),
+        ('%{__perl} Makefile.PL', scl_enable + '%{__perl} Makefile.PL\n' + scl_disable),
+        (' %{__perl} Makefile.PL', scl_enable + ' %{__perl} Makefile.PL\n' + scl_disable),
+        ('./Build', scl_enable + './Build\n' + scl_disable),
+    ])
+    def test_perl_specific_commands_matching(self, spec, expected):
+        spec = self.make_prep(spec)
+        pattern = self.get_pattern_for_spec(self.t.handle_perl_specific_commands, spec)
+        assert pattern
+        assert self.t.handle_perl_specific_commands(spec, pattern, spec) == self.make_prep(expected)

--- a/tests/test_php_transformer.py
+++ b/tests/test_php_transformer.py
@@ -17,5 +17,6 @@ class TestPHPTransformer(TransformerTestCase):
     ])
     def test_php_specific_commands_matching(self, spec, expected):
         spec = self.make_prep(spec)
-        handler = self.t.handle_php_specific_commands
-        assert self.t.handle_php_specific_commands(spec, self.get_pattern_for_spec(handler, spec), spec) == self.make_prep(expected)
+        pattern = self.get_pattern_for_spec(self.t.handle_php_specific_commands, spec)
+        assert pattern
+        assert self.t.handle_php_specific_commands(spec, pattern, spec) == self.make_prep(expected)

--- a/tests/test_python_transformer.py
+++ b/tests/test_python_transformer.py
@@ -4,6 +4,7 @@ from spec2scl.transformers.python import PythonTransformer
 
 from tests.transformer_test_case import TransformerTestCase, scl_enable, scl_disable
 
+
 class TestPythonTransformer(TransformerTestCase):
     def setup_method(self, method):
         self.t = PythonTransformer({})
@@ -16,5 +17,6 @@ class TestPythonTransformer(TransformerTestCase):
     ])
     def test_python_specific_commands_matching(self, spec, expected):
         spec = self.make_prep(spec)
-        handler = self.t.handle_python_specific_commands
-        assert self.t.handle_python_specific_commands(spec, self.get_pattern_for_spec(handler, spec), spec) == self.make_prep(expected)
+        pattern = self.get_pattern_for_spec(self.t.handle_python_specific_commands, spec)
+        assert pattern
+        assert self.t.handle_python_specific_commands(spec, pattern, spec) == self.make_prep(expected)

--- a/tests/test_ruby_transformer.py
+++ b/tests/test_ruby_transformer.py
@@ -15,7 +15,7 @@ class TestRubyTransformer(TransformerTestCase):
     def test_ruby_specific_commands_not_matching(self, spec):
         spec = self.make_prep(spec)
         handler = self.t.handle_ruby_specific_commands
-        assert self.get_pattern_for_spec(handler, spec) == None
+        assert self.get_pattern_for_spec(handler, spec) is None
 
     @pytest.mark.parametrize(('spec', 'expected'), [
         ('gem install spam', scl_enable + 'gem install spam\n' + scl_disable),
@@ -24,8 +24,10 @@ class TestRubyTransformer(TransformerTestCase):
         ('RUBYOPT="-Ilib:test" rspec spec\n', scl_enable + 'RUBYOPT="-Ilib:test" rspec spec\n' + scl_disable),
         ('testrb spam', scl_enable + 'testrb spam\n' + scl_disable),
         ('ruby -some params', scl_enable + 'ruby -some params\n' + scl_disable),
+        (' ruby -some params', scl_enable + ' ruby -some params\n' + scl_disable),
     ])
     def test_ruby_specific_commands_matching(self, spec, expected):
         spec = self.make_prep(spec)
-        handler = self.t.handle_ruby_specific_commands
-        assert self.t.handle_ruby_specific_commands(spec, self.get_pattern_for_spec(handler, spec), spec) == self.make_prep(expected)
+        pattern = self.get_pattern_for_spec(self.t.handle_ruby_specific_commands, spec)
+        assert pattern
+        assert self.t.handle_ruby_specific_commands(spec, pattern, spec) == self.make_prep(expected)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -130,6 +130,7 @@ class TestTransformer(TransformerTestCase):
     @pytest.mark.parametrize(('spec'), [
         ('# ham\n'),
         ('blahblah # ham\n'),
+        ('# %%gem_install - this is a comment'),
     ])
     def test_ignores_commented_commands(self, spec):
         assert 'enable' not in self.t.transform(spec)

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,7 @@ skip_missing_interpreters = true
 
 [testenv]
 commands = {envpython} setup.py test
+
+[pytest]
+addopts = 
+    --verbose


### PR DESCRIPTION
- Verbose output when running tests
- Accept arbitrary whitespace sequence if the transformer matches the beginning of the line (Issue #15)
- Make sure comments are not sclized (Issue #19)
- Add some code documentation
- Do some refactoring for transformer `find_whole_commands` method