### PR TITLE
Add support for custom prefixes in "list-files"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,9 @@ Usage (print this by running spec2scl -h)::
                             -l).
       -l SCL_CONTENTS_LIST, --list-file SCL_CONTENTS_LIST
                             List of the packages/provides, that will be in the SCL
-                            (to convert Requires/BuildRequires properly).
+                            (to convert Requires/BuildRequires properly). Lines in
+                            the file are in form of "pkg-name %{?custom_prefix}",
+                            where the prefix part is optional.
 
 
 

--- a/spec2scl/bin.py
+++ b/spec2scl/bin.py
@@ -9,11 +9,12 @@ def handle_scl_deps(no_deps_convert, args_list_file):
     if no_deps_convert:
         scl_deps = False
     elif args_list_file:
-        scl_deps = []
+        scl_deps = {}
         with open(args_list_file) as l:
             for i in l.readlines():
-                scl_deps.append(i.strip())
-
+                pair = i.split()
+                if pair:
+                    scl_deps[pair[0]] = pair[1] if len(pair) >= 2 else ''
     return scl_deps
 
 
@@ -64,7 +65,8 @@ def main():
                      )
     grp.add_argument('-l', '--list-file',
                      required=False,
-                     help='List of the packages/provides, that will be in the SCL (to convert Requires/BuildRequires properly).',
+                     help=('List of the packages/provides, that will be in the SCL (to convert Requires/BuildRequires properly). '
+                           'Lines in the file are in form of "pkg-name %%{?custom_prefix}", where the prefix part is optional.'),
                      metavar='SCL_CONTENTS_LIST'
                      )
 

--- a/spec2scl/transformers/generic.py
+++ b/spec2scl/transformers/generic.py
@@ -30,10 +30,17 @@ class GenericTransformer(transformer.Transformer):
             scl_deps = self.options['scl_deps']
 
             if scl_deps == True or (scl_deps_effect and scl_deps and groupdict['dep'] in scl_deps):
-                if groupdict['dep'].startswith('/'):
-                    dep = '%{{?_scl_root}}{0}'.format(groupdict['dep'])
-                else:
-                    dep = '%{{?scl_prefix}}{0}'.format(groupdict['dep'])
+                prefix = ''
+                if isinstance(scl_deps, dict):
+                    prefix = scl_deps[groupdict['dep']]
+
+                if not prefix:
+                    if groupdict['dep'].startswith('/'):
+                        prefix = '%{?_scl_root}'
+                    else:
+                        prefix = '%{?scl_prefix}'
+
+                dep = '{0}{1}'.format(prefix, groupdict['dep'])
             else:
                 dep = groupdict['dep']
 

--- a/tests/test_generic_transformer.py
+++ b/tests/test_generic_transformer.py
@@ -59,9 +59,11 @@ class TestGenericTransformer(TransformerTestCase):
         ('Requires: spam > 1, spam < 3', True, 'Requires: %{?scl_prefix}spam > 1, %{?scl_prefix}spam < 3'),
         ('BuildRequires: python-%{spam}', True, 'BuildRequires: %{?scl_prefix}python-%{spam}'),
         ('BuildRequires: python-%{spam}', False, 'BuildRequires: python-%{spam}'),
-        ('Requires: spam > 1, spam < 3', ['eggs'], 'Requires: spam > 1, spam < 3'),
-        ('Requires: spam > 1, spam < 3', ['spam'], 'Requires: %{?scl_prefix}spam > 1, %{?scl_prefix}spam < 3'),
-        ('BuildRequires: python(spam)', ['python(spam)', 'spam'], 'BuildRequires: %{?scl_prefix}python(spam)'),
+        ('Requires: spam > 1, spam < 3', {'eggs': ''}, 'Requires: spam > 1, spam < 3'),
+        ('Requires: spam > 1, spam < 3', {'spam': ''}, 'Requires: %{?scl_prefix}spam > 1, %{?scl_prefix}spam < 3'),
+        ('BuildRequires: python(spam)', {'python(spam)': '', 'spam': ''}, 'BuildRequires: %{?scl_prefix}python(spam)'),
+        ('BuildRequires: python(spam)', {'python(spam)': '%{?scl_prefix_python27}'}, 'BuildRequires: %{?scl_prefix_python27}python(spam)'),
+        ('BuildRequires: spam', {'egg': '%{?scl_prefix_python27}'}, 'BuildRequires: spam'),
     ])
     def test_handle_dependency_tag_modified_scl_deps(self, spec, scl_deps, expected):
         handler = self.t.handle_dependency_tag_modified_by_list


### PR DESCRIPTION
This Pull Request was initially opened by **Michal Srb(Bitbucket: [msrb](https://bitbucket.org/msrb), GitHub: [msrb](https://github.com/msrb))**
Bitbucket: https://bitbucket.org/bkabrda/spec2scl/pull-requests/2

SCLs can sometimes depend on other SCLs. "list-files" currently only allow to express dependency on a package from the same SCL (or on a package from base system, if omitted from the list). This PR adds option to specify custom prefix in the "list-file" that should be used instead of implicit prefix.

Example:

```
$ cat LIST 
mvn(junit:junit)
mvn(org.apache.commons:commons-io) %{?scl_prefix_java_common}

$ cat pkg.spec | grep BuildRequires
BuildRequires:  maven-local
BuildRequires:  mvn(junit:junit)
BuildRequires:  mvn(org.apache.commons:commons-io)

$ spec2scl -l LIST pkg.spec | grep BuildRequires
BuildRequires:  maven-local
BuildRequires:  %{?scl_prefix}mvn(junit:junit)
BuildRequires:  %{?scl_prefix_java_common}mvn(org.apache.commons:commons-io)
```