### PR TITLE
Add `set -e` and wrap whole section in a single "scl enable" 

### DIFF
--- a/spec2scl/transformer.py
+++ b/spec2scl/transformer.py
@@ -117,39 +117,31 @@ class Transformer(object):
         """
         # TODO: this is getting ugly, refactor
         commands = []
-        while(True):
+
+        while text:
             # find the matched string (usually beginning of command) inside text
             match = pattern.search(''.join(text))
             if not match:
-                break
-            matched = match.group(0)
-            if matched.endswith('\n'):
-                # if matched ends with newline, then we might have got e.g.
-                # 'make\n\n', but that will not work because we are splitting
-                # lines below, so we can only match one newline at the end
-                matched = matched.rstrip('\n') + '\n'
+                return commands
 
-            append = False
-            whole_command = []
             # now use it to get the whole command
-            index = match.start(0)
-            previous_newline = text.rfind('\n', 0, index)
+            previous_newline = text.rfind('\n', 0, match.start(0))
             # don't start from the matched pattern, but from the beginning of its line
-            text = text[previous_newline if previous_newline != -1 else 0:]
+            text = text[previous_newline + 1:]
+            whole_comamnd = []
             for line in text.splitlines(True):
-                if line.find(matched) != -1:
-                    append = True
-                if append:
-                    whole_command.append(line)
-                if append and not line.rstrip().endswith('\\'):
-                    break  # sorry :)
+                whole_comamnd.append(line)
+                if not line.rstrip().endswith('\\'):
+                    break
 
-            command = ''.join(whole_command)
-            text = text[len(command):]  # so that we don't find it again
+            command = ''.join(whole_comamnd)
+            # Do not sclize commented matches.
             comment_index = command.find('#')
-            # only append if not matched
+            matched = match.group(0).rstrip()
             if comment_index == -1 or command.find(matched) < comment_index:
                 commands.append(command)
+
+            text = text[len(command):]
 
         return commands
 

--- a/spec2scl/transformer.py
+++ b/spec2scl/transformer.py
@@ -117,8 +117,11 @@ class Transformer(object):
         """
         # TODO: this is getting ugly, refactor
         commands = []
-        for match in pattern.finditer(''.join(text)):
+        while(True):
             # find the matched string (usually beginning of command) inside text
+            match = pattern.search(''.join(text))
+            if not match:
+                break
             matched = match.group(0)
             if matched.endswith('\n'):
                 # if matched ends with newline, then we might have got e.g.
@@ -132,16 +135,17 @@ class Transformer(object):
             index = match.start(0)
             previous_newline = text.rfind('\n', 0, index)
             # don't start from the matched pattern, but from the beginning of its line
-            stripped_text = text[previous_newline if previous_newline != -1 else 0:]
-            for line in stripped_text.splitlines(True):
+            text = text[previous_newline if previous_newline != -1 else 0:]
+            for line in text.splitlines(True):
                 if line.find(matched) != -1:
                     append = True
                 if append:
                     whole_command.append(line)
-                    if not line.rstrip().endswith('\\'):
-                        break  # sorry :)
+                if append and not line.rstrip().endswith('\\'):
+                    break  # sorry :)
 
             command = ''.join(whole_command)
+            text = text[len(command):]  # so that we don't find it again
             comment_index = command.find('#')
             # only append if not matched
             if comment_index == -1 or command.find(matched) < comment_index:

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -70,6 +70,8 @@ class TestTransformer(TransformerTestCase):
 
     @pytest.mark.parametrize(('pattern', 'spec', 'expected'), [
         (re.compile(r'eat spam'), 'eat spam\neat eat spam', ['eat spam\n', 'eat eat spam']),
+        (re.compile(r'eat spam'), 'eat spam\\\neat eat spam', ['eat spam\\\neat eat spam']),
+        (re.compile(r'eat spam'), 'eat spam\\\neat \\ \n eat spam', ['eat spam\\\neat \\ \n eat spam']),
         (re.compile(r'eat spam'), 'spam eat\nand spam', []),
         (re.compile(r'eat spam'), 'eat spam \\\n and ham', ['eat spam \\\n and ham']),
         (re.compile(r'eat spam'), 'SPAM=SPAM eat spam', ['SPAM=SPAM eat spam']),
@@ -115,7 +117,8 @@ class TestTransformer(TransformerTestCase):
         assert self.st.transform_more_liners(spec, '%prep', spec) == expected
 
     @pytest.mark.parametrize(('spec', 'expected'), [
-        ('looney\nlooney\n', scl_enable + 'looney\n' + scl_disable + scl_enable + 'looney\n' + scl_disable),
+        ('looney\nlooney\n', '{0}looney\n{1}{0}looney\n{1}'.format(scl_enable, scl_disable)),
+        ('ham\n\n', '{0}ham\n{1}\n'.format(scl_enable, scl_disable)),
     ])
     def test_transformers_dont_apply_scl_enable_twice(self, spec, expected):
         assert self.st.transform_more_liners(spec, '%prep', spec) == expected

--- a/tests/transformer_test_case.py
+++ b/tests/transformer_test_case.py
@@ -1,8 +1,7 @@
-from spec2scl import settings
 from spec2scl import specfile
 
 
-scl_enable = '%{?scl:scl enable %{scl} - << \EOF}\n'
+scl_enable = '%{?scl:scl enable %{scl} - << \EOF}\nset -e\n'
 scl_disable = '%{?scl:EOF}\n'
 
 


### PR DESCRIPTION
- Reverted and reworked 9a02d4d as it introduced regression. Added more tests.
- Fix issue #17:
    * Do `set -e` so that the script behaviour is consistent regardless of whether the script is executed in the rpm shell or the scl environment. 
    https://bugzilla.redhat.com/show_bug.cgi?id=1184515
    https://www.softwarecollections.org/en/docs/guide/#sect-Converting_RPM_Scripts
    * Wrap whole section in a single "scl enable"