### PR TITLE
In handle_name_macro, add exemptions for some RPM dep directives

### DIFF
--- a/spec2scl/transformers/generic.py
+++ b/spec2scl/transformers/generic.py
@@ -80,6 +80,10 @@ class GenericTransformer(transformer.Transformer):
 
     @matches(r'%{name}', sections=settings.SPECFILE_SECTIONS)
     def handle_name_macro(self, original_spec, pattern, text):
+        # instances of name macro in these tags should be left alone because they are
+        # intentionally referring to the name of the rpm we are currently processing
+        if text.startswith(('Obsoletes:', 'Provides:', 'Requires:', 'BuildRequires:')):
+            return text
         return pattern.sub(r'%{pkg_name}', text)
 
     @matches(r'.*', one_line=False, sections=['%header'])


### PR DESCRIPTION
We shouldn't transform the %{name} macro for Obsoletes, Provides,
Requires, BuildRequires tags because it will erroneously refer to
base OS packages instead of SCL packages.

For example, if an RPM has renamed one of its sub-packages, then
transforming the following lines:

Obsoletes: %{name}-subpackage
Provides:  %{name}-subpackage

To this:

Obsoletes: %{pkg_name}-subpackage
Provides:  %{pkg_name}-subpackage

Would result in obsoleting/providing a base OS package instead,
which could potentially break a user's system. Such cases must
be left alone.