### PR TITLE
Make spec2scl aware of scriptlet runtime sections

### DIFF
--- a/spec2scl/settings.py
+++ b/spec2scl/settings.py
@@ -9,10 +9,16 @@ SPECFILE_SECTIONS = ['%header',  # special "section" for the start of specfile
                      '%install',
                      '%clean',
                      '%check',
+                     '%pre',
+                     '%post',
+                     '%preun',
+                     '%postun',
+                     '%pretrans',
+                     '%posttrans',
                      '%files',
                      '%changelog']
 
-RUNTIME_SECTIONS = ['%prep', '%build', '%install', '%clean', '%check']
+RUNTIME_SECTIONS = ['%prep', '%build', '%install', '%clean', '%check', '%pre', '%post', '%preun', '%postun', '%pretrans', '%posttrans']
 METAINFO_SECTIONS = ['%header', '%package']
 
 SCL_ENABLE = '%{?scl:scl enable %{scl} - << \EOF}\nset -ex\n'

--- a/spec2scl/specfile.py
+++ b/spec2scl/specfile.py
@@ -30,7 +30,7 @@ class Specfile(object):
         Return:
             list of (section name, section text)
         """
-        headers_re = [re.compile('^' + x, re.M) for x in settings.SPECFILE_SECTIONS]
+        headers_re = [re.compile('^' + x + '\\b', re.M) for x in settings.SPECFILE_SECTIONS]
         section_starts = []
         for header in headers_re:
             for match in header.finditer(self.specfile):
@@ -47,7 +47,7 @@ class Specfile(object):
                 curr_section = self.specfile[section_starts[i]:]
             for header in headers_re:
                 if header.match(curr_section):
-                    sections.append((header.pattern[1:], curr_section))
+                    sections.append((header.pattern[1:-2], curr_section))
 
         return sections
 

--- a/tests/test_generic_transformer.py
+++ b/tests/test_generic_transformer.py
@@ -133,7 +133,7 @@ class TestGenericTransformer(TransformerTestCase):
         ('%build\ntest\n\n', '%build\n{0}test\n{1}'.format(scl_enable, scl_disable)),
         ('%prep\ntest\ntest\n\n', '%prep\n{0}test\ntest\n{1}'.format(scl_enable, scl_disable)),
         ('%check\ntest \\\ntest\n\n', '%check\n{0}test \\\ntest\n{1}'.format(scl_enable, scl_disable)),
-        ('%install\ntest\n\n%postun\ntrue\n\n', '%install\n{0}test\n{1}\n\n%postun\n{2}true\n{3}'.format(scl_enable, scl_disable, scl_enable, scl_disable)),
+        ('%install\ntest\n\n%postun\ntrue\n\n', '%install\n{0}test\n{1}\n\n%postun\n{0}true\n{1}'.format(scl_enable, scl_disable)),
     ])
     def test_sclize_runtime_sections(self, spec, expected):
         transformed = self.t.transform(spec)

--- a/tests/test_generic_transformer.py
+++ b/tests/test_generic_transformer.py
@@ -133,6 +133,7 @@ class TestGenericTransformer(TransformerTestCase):
         ('%build\ntest\n\n', '%build\n{0}test\n{1}'.format(scl_enable, scl_disable)),
         ('%prep\ntest\ntest\n\n', '%prep\n{0}test\ntest\n{1}'.format(scl_enable, scl_disable)),
         ('%check\ntest \\\ntest\n\n', '%check\n{0}test \\\ntest\n{1}'.format(scl_enable, scl_disable)),
+        ('%install\ntest\n\n%postun\ntrue\n\n', '%install\n{0}test\n{1}\n\n%postun\n{2}true\n{3}'.format(scl_enable, scl_disable, scl_enable, scl_disable)),
     ])
     def test_sclize_runtime_sections(self, spec, expected):
         transformed = self.t.transform(spec)


### PR DESCRIPTION
Ensures correct sclisation of spec files that contain scriptlet
sections such as %pre and %post

Previously, if your spec contained, for example:

```
%install
install_stuff

%postun
do_stuff

%files
```
Then spec2scl would incorrectly transform it to this:
```

%install
%{?scl:scl enable %{scl} - << \EOF}
set -ex
install_stuff

%postun
do_stuff
%{?scl:EOF}

%files
```

Which clearly breaks both scriptlets due to missing EOF in %install and an extra EOF in %postun. This change teaches spec2scl about all the scriptlets so they can transformed correctly.

Additional test case parameter is also added.