### PR TITLE
Add support for transforming scriptlet-specific dependencies

### DIFF
--- a/spec2scl/transformers/generic.py
+++ b/spec2scl/transformers/generic.py
@@ -55,7 +55,7 @@ class GenericTransformer(transformer.Transformer):
         dep_re = re.compile(r'(?P<prespace>\s*)(?P<dep>([^\s]+(.+\))?))(?P<ver>\s*[<>=!]+\s*[^\s]+)?(?P<postspace>\s*)')
         return tag + dep_re.sub(handle_one_dep, deps)
 
-    @matches(r'(?<!d)(Requires:\s*)(?!\w*/\w*)([^[\s]+)', sections=settings.METAINFO_SECTIONS)  # avoid BuildRequires
+    @matches(r'(?<!d)(Requires(\([a-z]+\))?:\s*)(?!\w*/\w*)([^[\s]+)', sections=settings.METAINFO_SECTIONS)  # avoid BuildRequires
     @matches(r'(BuildRequires:\s*)(?!\w*/\w*)([^\s]+)', sections=settings.METAINFO_SECTIONS)
     def handle_dependency_tag_modified_by_list(self, original_spec, pattern, text):
         return self.handle_dependency_tag(original_spec, pattern, text, True)

--- a/tests/test_data/scl_test.spec
+++ b/tests/test_data/scl_test.spec
@@ -27,6 +27,10 @@ BuildRequires:  %{?scl_prefix}python3-pytest
 Requires:       %{?scl_prefix}python3-setuptools
 Requires:       %{?scl_prefix}python3-jinja2
 
+# Scriptlet-specific requirements
+Requires(pre):  %{?scl_prefix}some-package
+Requires(post): %{?scl_prefix}some-package
+
 
 %description
 spec2scl is a tool to convert RPM specfiles to SCL-style specfiles.

--- a/tests/test_data/test.spec
+++ b/tests/test_data/test.spec
@@ -22,6 +22,10 @@ BuildRequires:  python3-pytest
 Requires:       python3-setuptools
 Requires:       python3-jinja2
 
+# Scriptlet-specific requirements
+Requires(pre):  some-package
+Requires(post): some-package
+
 %description
 spec2scl is a tool to convert RPM specfiles to SCL-style specfiles.
 

--- a/tests/test_generic_transformer.py
+++ b/tests/test_generic_transformer.py
@@ -49,6 +49,7 @@ class TestGenericTransformer(TransformerTestCase):
     @pytest.mark.parametrize(('spec', 'expected'), [
         ('Requires: /foo/spam', 'Requires: %{?_scl_root}/foo/spam'),
         ('Requires: spam /foo/eggs', 'Requires: %{?scl_prefix}spam %{?_scl_root}/foo/eggs'),
+        ('Requires(pre): javapackages-tools', 'Requires(pre): %{?scl_prefix}javapackages-tools'),
     ])
     def test_handle_dependency_tag_with_path(self, spec, expected):
         handler = self.t.handle_dependency_tag
@@ -64,6 +65,7 @@ class TestGenericTransformer(TransformerTestCase):
         ('BuildRequires: python(spam)', {'python(spam)': '', 'spam': ''}, 'BuildRequires: %{?scl_prefix}python(spam)'),
         ('BuildRequires: python(spam)', {'python(spam)': '%{?scl_prefix_python27}'}, 'BuildRequires: %{?scl_prefix_python27}python(spam)'),
         ('BuildRequires: spam', {'egg': '%{?scl_prefix_python27}'}, 'BuildRequires: spam'),
+        ('Requires(post): javapackages-tools', {'javapackages-tools': '%{?scl_prefix_maven}'}, 'Requires(post): %{?scl_prefix_maven}javapackages-tools'),
     ])
     def test_handle_dependency_tag_modified_scl_deps(self, spec, scl_deps, expected):
         handler = self.t.handle_dependency_tag_modified_by_list


### PR DESCRIPTION
Previously spec2scl would ignore these lines entirely because
the regular expression did not match them. This change fixes
the regex to match scriptlet-specific requires and adds some
extra test data.
