### PR TITLE
Drop pytest-runner and "setup.py test" support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,8 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['tests']),
     package_data={'spec2scl': ['templates/*.spec']},
-    setup_requires=['pytest-runner',
-                    'flexmock >= 0.9.3'
-                    ] + install_requires,
+    setup_requires=['flexmock >= 0.9.3'] + install_requires,
     install_requires=install_requires,
-    tests_require=['pytest'],
     entry_points={'console_scripts': ['spec2scl = spec2scl.bin:main']},
     classifiers=['Development Status :: 4 - Beta',
                  'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@ skip_missing_interpreters = true
 
 [testenv]
 deps =
+    pytest
     pytest-flakes
     pytest-pep8
 
-commands = {envpython} setup.py test
+commands = {envpython} -m pytest {posargs}
 
 [pytest]
 addopts =


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
Remove `pytest-runner` from `setup_requires`, and remove `test_requires`, which is deprecated and only useful with `setup.py test`.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with `pytest` or `tox`.